### PR TITLE
changes NSImage category visibility to internal and non-objc to avoid…

### DIFF
--- a/lottie-swift/src/Public/MacOS/FilepathImageProvider.swift
+++ b/lottie-swift/src/Public/MacOS/FilepathImageProvider.swift
@@ -55,8 +55,8 @@ public class FilepathImageProvider: AnimationImageProvider {
   
 }
 
-extension NSImage {
-  @objc var CGImage: CGImage? {
+internal extension NSImage {
+  @nonobjc var CGImage: CGImage? {
     get {
       guard let imageData = self.tiffRepresentation else { return nil }
       guard let sourceData = CGImageSourceCreateWithData(imageData as CFData, nil) else { return nil }


### PR DESCRIPTION
… collision with categrories outside current module